### PR TITLE
Fix leaks and process waiting in philo_bonus

### DIFF
--- a/philo_bonus/forks.c
+++ b/philo_bonus/forks.c
@@ -84,12 +84,13 @@ int	create_philo_fork(t_table *t, int id)
 int	start_forks(t_table *t)
 {
 	pid_t	pid;
+	int	status;
 
 	t->start_time = get_time_in_ms();
 	if (t->n_philos == 1)
 	{
 		pid = single_philo(t);
-		waitpid(-1, &pid, 0);
+		waitpid(pid, &status, 0);
 	}
 	else if (start_philo_process(t))
 		return (1);

--- a/philo_bonus/structs.c
+++ b/philo_bonus/structs.c
@@ -40,13 +40,16 @@ void	set_args(t_table *t, int ac, char **av)
 
 int	alloc_table(t_table *t)
 {
-	t->philos = malloc(sizeof(t_philo) * t->n_philos);
-	if (!t->philos)
-		return (1);
-	t->pid = (pid_t *) malloc(sizeof(pid_t) * t->n_philos);
-	if (!t->philos)
-		return (1);
-	return (0);
+       t->philos = malloc(sizeof(t_philo) * t->n_philos);
+       if (!t->philos)
+               return (1);
+       t->pid = malloc(sizeof(pid_t) * t->n_philos);
+       if (!t->pid)
+       {
+               free(t->philos);
+               return (1);
+       }
+       return (0);
 }
 
 int	init_philos(t_table *t)


### PR DESCRIPTION
## Summary
- fix pid allocation error
- wait for single child with correct pid

## Testing
- `make -C philo`
- `valgrind ./philo 2 800 200 200 1`
- `make -C philo_bonus`
- `valgrind --leak-check=full ./philo_bonus 2 800 200 200`

------
https://chatgpt.com/codex/tasks/task_e_68699c09cab88330a9a2b5433cd5433d